### PR TITLE
chore: set public port for https as env variable for easier management.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     networks:
       - transcendence_net
     ports:
-      - "8443:443"
+      - "${HTTPS_PORT}:443"
     environment:
       - DOMAIN=${DOMAIN}
     depends_on:

--- a/example.env
+++ b/example.env
@@ -1,4 +1,5 @@
 DOMAIN="example.com"
+HTTPS_PORT=443
 
 DB_PATH=/data/database.sqlite
 


### PR DESCRIPTION
This PR introduces a new `.env` variable `HTTPS_PORT` to configure the HTTPS port in the `docker-compose.yml`.

### Changes:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L65-R65): Replaced hardcoded HTTPS port (`8443`) with `${HTTPS_PORT}`.
* [`example.env`](diffhunk://#diff-a714eca19b6f8db4dbfbd978aa5325b98cc0550fe4c1e7953e8b1eb136cb925aR2): Added `HTTPS_PORT` variable with a default value of `443`.
